### PR TITLE
Update French translation files after POT update

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -11,7 +11,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/jenslody/gnome-shell-extension-"
 "openweather/issues\n"
 "POT-Creation-Date: 2016-10-04 00:34+0200\n"
-"PO-Revision-Date: 2016-10-02 01:00+0200\n"
+"PO-Revision-Date: 2016-10-04 11:00+0200\n"
 "Last-Translator: Davy Defaud (DevDef) <davy.defaud@free.fr>\n"
 "Language-Team: Français <ecyrbe@gmail.com>\n"
 "Language: fr\n"
@@ -582,7 +582,7 @@ msgid "Provider"
 msgstr "Fournisseur"
 
 #: src/prefs.js:553
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "Remove %s ?"
 msgstr "Supprimer %s ?"
 
@@ -636,9 +636,8 @@ msgid "Personal Api key from openweathermap.org"
 msgstr "Clef d’API personnelle d’openweathermap.org"
 
 #: data/weather-settings.ui:549
-#, fuzzy
 msgid "Personal Api key from Dark Sky"
-msgstr "Clef d’API personnelle de Dark Sky"
+msgstr "Clef d’API personnelle de Dark Sky"
 
 #: data/weather-settings.ui:562
 msgid "Refresh timeout for current weather [min]"
@@ -649,7 +648,6 @@ msgid "Refresh timeout for weather forecast [min]"
 msgstr "Délai avant rafraîchissement des prévisions météo [min]"
 
 #: data/weather-settings.ui:604
-#, fuzzy
 msgid ""
 "Note: the forecast-timout is not used for Dark Sky, because they do not "
 "provide seperate downloads for current weather and forecasts."
@@ -790,7 +788,6 @@ msgid "unknown (self-build ?)"
 msgstr "inconnu (auto‐compilation ?)"
 
 #: data/weather-settings.ui:1252
-#, fuzzy
 msgid ""
 "<span>Weather extension to display weather information from <a href="
 "\"https://openweathermap.org/\">Openweathermap</a> or <a href=\"https://"
@@ -798,7 +795,7 @@ msgid ""
 msgstr ""
 "<span>Extension GNOME Shell permettant l’affichage des informations météo "
 "d’<a href=\"https://openweathermap.org/\">Openweathermap</a> ou <a href="
-"\"https://darksky.net\">Dark Sky</a>\n"
+"\"https://darksky.net\">Dark Sky</a>\n"
 " pour la plupart des localisations dans le monde.</span>"
 
 #: data/weather-settings.ui:1275
@@ -887,10 +884,9 @@ msgid "Use the extensions default API key from openweathermap.org"
 msgstr "Utiliser la clef d’API d’extension pour openweathermap.org"
 
 #: data/org.gnome.shell.extensions.openweather.gschema.xml:148
-#, fuzzy
 msgid "Your personal API key from Dark Sky"
-msgstr "Clef d’API personnelle de Dark Sky"
+msgstr "Clef d’API personnelle de Dark Sky"
 
 #: data/org.gnome.shell.extensions.openweather.gschema.xml:152
 msgid "Your personal AppKey from developer.geocode.farm"
-msgstr "AppKey personnelle de developer.mapquest.com"
+msgstr "Clef d’API personnelle de geocode.farm"


### PR DESCRIPTION
Latest POT update for darksky.net change to Dark Sky has marked all msgstrs containing “darksky.net” as “fuzzy” in all PO translation files.
This is the correction for French PO file. Plus, I replaced the space in “Dark Sky” by a non breaking space in the msgstr.

developer.geocode.farm answers with 404 error! Change to geocode.farm (will be marked as fuzzy when POT will be updated…)