### PR TITLE
Baromotric patch

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -124,7 +124,8 @@ const WeatherPressureUnits = {
     AT: 6,
     TORR: 7,
     PSI: 8,
-    MMHG: 9
+    MMHG: 9,
+    MBAR: 10
 };
 
 const WeatherPosition = {
@@ -1240,8 +1241,13 @@ const OpenweatherMenuButton = new Lang.Class({
                 break;
 
             case WeatherPressureUnits.BAR:
-                pressure = (pressure / 1000).toFixed(this._decimal_places);
+                pressure = (pressure / 100000).toFixed(this._decimal_places);
                 pressure_unit = _("bar");
+                break;
+            
+            case WeatherPressureUnits.MBAR:
+                pressure = (pressure / 100).toFixed(this._decimal_places);
+                presure_unit = _("mbar");
                 break;
 
             case WeatherPressureUnits.PA:

--- a/src/extension.js
+++ b/src/extension.js
@@ -1241,12 +1241,12 @@ const OpenweatherMenuButton = new Lang.Class({
                 break;
 
             case WeatherPressureUnits.BAR:
-                pressure = (pressure / 100000).toFixed(this._decimal_places);
+                pressure = (pressure / 1000).toFixed(this._decimal_places);
                 pressure_unit = _("bar");
                 break;
             
             case WeatherPressureUnits.MBAR:
-                pressure = (pressure / 100).toFixed(this._decimal_places);
+                pressure = pressure.toFixed(this._decimal_places);
                 presure_unit = _("mbar");
                 break;
 


### PR DESCRIPTION
I've no Idea about translation in PO files, so there are not any additions/changes there.
It seem the german translation is should be patched also with
```

#: src/extension.js:1249 data/weather-settings.ui:830
msgid "Pa"
msgstr "Pa"
```
Instead of translating it to bar.
