### PR TITLE
Add correct package name for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Install the package through APT (or use your favourite package-manager, e.g. syn
 
 You can install the extension from the official Fedora repos.
 
+Install the package through DNF 
+
+	sudo dnf install gnome-shell-extension-openweather
+	
+
 ### [Arch Linux (AUR)](https://aur.archlinux.org/packages/gnome-shell-extension-openweather-git/)
 
 	sudo yaourt -S gnome-shell-extension-openweather-git


### PR DESCRIPTION
In Fedora there is no package called `gnome-shell-extension-weather`, but `gnome-shell-extension-openweather` is present.