### PR TITLE
Fixed issue where if the name of the city is too long, the weather popup extends out of the screen

### DIFF
--- a/data/org.gnome.shell.extensions.openweather.gschema.xml
+++ b/data/org.gnome.shell.extensions.openweather.gschema.xml
@@ -120,6 +120,10 @@
       <default>600</default>
       <summary>Refresh interval (actual weather)</summary>
     </key>
+    <key type="i" name="location-text-length">
+      <default>0</default>
+      <summary>Maximal length of the location text</summary>
+    </key>
     <key type="i" name="refresh-interval-forecast">
       <default>3600</default>
       <summary>Refresh interval (forecast)</summary>

--- a/data/weather-settings.ui
+++ b/data/weather-settings.ui
@@ -175,6 +175,13 @@
     <property name="step_increment">0.10000000000000001</property>
     <property name="page_increment">2</property>
   </object>
+  <object class="GtkAdjustment" id="max-loc-chars-adj">
+    <property name="lower">0</property>
+    <property name="upper">500</property>
+    <property name="value">50</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkMenu" id="search-menu">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -1136,6 +1143,34 @@
           <packing>
             <property name="left_attach">1</property>
             <property name="top_attach">11</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="max-characters-in-location">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="hexpand">True</property>
+            <property name="label" translatable="yes">Maximal number of characters in location label</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">12</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="max_loc_chars">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="input_purpose">number</property>
+            <property name="adjustment">max-loc-chars-adj</property>
+            <property name="climb_rate">5</property>
+            <property name="numeric">True</property>
+            <property name="value">0</property>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">12</property>
           </packing>
         </child>
       </object>

--- a/src/darksky_net.js
+++ b/src/darksky_net.js
@@ -174,7 +174,10 @@ function parseWeatherCurrent() {
     this._weatherInfo.text = weatherInfoC + ((weatherInfoC && weatherInfoT) ? _(", ") : "") + weatherInfoT;
 
     this._currentWeatherSummary.text = comment + _(", ") + temperature;
-    this._currentWeatherLocation.text = location;
+    if (this._loc_len_current != 0 && location.length > this._loc_len_current)
+        this._currentWeatherLocation.text = location.substring(0, (this._loc_len_current - 3)) + "...";
+    else
+        this._currentWeatherLocation.text = location;
     this._currentWeatherCloudiness.text = parseInt(json.cloudCover * 100) + ' %';
     this._currentWeatherHumidity.text = parseInt(json.humidity * 100) + ' %';
     this._currentWeatherPressure.text = this.formatPressure(json.pressure);

--- a/src/extension.js
+++ b/src/extension.js
@@ -86,6 +86,7 @@ const OPENWEATHER_USE_DEFAULT_OWM_API_KEY = 'use-default-owm-key';
 const OPENWEATHER_OWM_API_KEY = 'appid';
 const OPENWEATHER_OWM_DEFAULT_API_KEY = 'c93b4a667c8c9d1d1eb941621f899bb8';
 const OPENWEATHER_FC_API_KEY = 'appid-fc';
+const OPENWEATHER_LOC_TEXT_LEN = 'location-text-length'
 
 // Keep enums in sync with GSettings schemas
 const WeatherProvider = {
@@ -811,6 +812,13 @@ const OpenweatherMenuButton = new Lang.Class({
             this.loadConfig();
         let v = this._settings.get_int(OPENWEATHER_REFRESH_INTERVAL_FORECAST);
         return ((v >= 600) ? v : 600);
+    },
+
+    get _loc_len_current() {
+        if (!this._settings)
+            this.loadConfig();
+        let v = this._settings.get_int(OPENWEATHER_LOC_TEXT_LEN);
+        return ((v > 0) ? v : 0);
     },
 
     get _center_forecast() {

--- a/src/openweathermap_org.js
+++ b/src/openweathermap_org.js
@@ -366,7 +366,10 @@ function parseWeatherCurrent() {
     this._weatherInfo.text = weatherInfoC + ((weatherInfoC && weatherInfoT) ? _(", ") : "") + weatherInfoT;
 
     this._currentWeatherSummary.text = comment + _(", ") + temperature;
-    this._currentWeatherLocation.text = location;
+    if (this._loc_len_current != 0 && location.length > this._loc_len_current)
+        this._currentWeatherLocation.text = location.substring(0, (this._loc_len_current - 3)) + "...";
+    else
+        this._currentWeatherLocation.text = location;
     this._currentWeatherCloudiness.text = json.clouds.all + ' %';
     this._currentWeatherHumidity.text = json.main.humidity + ' %';
     this._currentWeatherPressure.text = this.formatPressure(json.main.pressure);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -71,6 +71,7 @@ const OPENWEATHER_USE_DEFAULT_OWM_API_KEY = 'use-default-owm-key';
 const OPENWEATHER_OWM_API_KEY = 'appid';
 const OPENWEATHER_FC_API_KEY = 'appid-fc';
 const OPENWEATHER_GC_APP_KEY = 'geolocation-appid-mapquest';
+const OPENWEATHER_LOC_TEXT_LEN = 'location-text-length'
 
 //URL
 const OPENWEATHER_URL_MAPQUEST_BASE = 'https://open.mapquestapi.com/nominatim/v1/';
@@ -395,6 +396,21 @@ const WeatherPrefsWidget = new GObject.Class({
         column.set_cell_data_func(renderer, function() {
             arguments[1].markup = arguments[2].get_value(arguments[3], 1);
         });
+
+        this.location_length_spin = this.Window.get_object("max_loc_chars");
+        this.location_length_spin.set_value(this.loc_len_current);
+        // prevent from continously updating the value
+        this.locLenSpinTimeout = undefined;
+        this.location_length_spin.connect("value-changed", Lang.bind(this, function(button) {
+
+            if (this.locLenSpinTimeout !== undefined)
+                Mainloop.source_remove(this.locLenSpinTimeout);
+            this.locLenSpinTimeout = Mainloop.timeout_add(250, Lang.bind(this, function() {
+                this.loc_len_current = button.get_value();
+                return false;
+            }));
+
+        }));
 
 
         let theObjects = this.Window.get_objects();
@@ -925,6 +941,19 @@ const WeatherPrefsWidget = new GObject.Class({
         if (!this.Settings)
             this.loadConfig();
         this.Settings.set_int(OPENWEATHER_REFRESH_INTERVAL_CURRENT, ((v >= 600) ? v : 600));
+    },
+
+    get loc_len_current() {
+        if (!this.Settings)
+            this.loadConfig();
+        let v = this.Settings.get_int(OPENWEATHER_LOC_TEXT_LEN);
+		return ((v > 0) ? v : 0);
+    },
+
+    set loc_len_current(v) {
+        if (!this.Settings)
+            this.loadConfig();
+		this.Settings.set_int(OPENWEATHER_LOC_TEXT_LEN, ((v > 0) ? v : 0));
     },
 
     get refresh_interval_forecast() {


### PR DESCRIPTION
When the city name is too long, the popup extends out of the screen. Now the user is able to set the number of characters to be displayed, or set the length to 0 for the default behaviour.